### PR TITLE
コア画面デザインの修正

### DIFF
--- a/frontend/app/app/components/Calender.jsx
+++ b/frontend/app/app/components/Calender.jsx
@@ -1,9 +1,15 @@
+"use client"
+import React, { useState, useEffect } from 'react';
+
 export default function Calendar() {
+  const [currentDate] = useState(new Date());
+
+
   return (
     <div className="calendar-container">
       <div className="calendar-contents">
         <img src="img/Calendar.png" alt="カレンダー" />
-        <div className="calendar-date">2024/2/5</div>
+        <div className="calendar-date">{currentDate.toISOString().split('T')[0]}</div>
       </div>
     </div>
   );

--- a/frontend/app/app/components/TaskList.jsx
+++ b/frontend/app/app/components/TaskList.jsx
@@ -1,9 +1,9 @@
 export default function TaskList() {
-
   return (
-    <div>
+    <div className="task-list-container">
       <div className="main-content-task-left">
         <div className="left-task-contents">
+          <h2>左側のタスクリスト</h2>
           <ul className="task-list">
             <li className="task-item">
               <label>
@@ -26,8 +26,13 @@ export default function TaskList() {
           </ul>
         </div>
       </div>
+      <div className="center-box">
+        {/* 中央の透明な箱 */}
+        <div className="transparent-box"></div>
+      </div>
       <div className="main-content-task-right">
         <div className="right-task-contents">
+          <h2>右側のタスクリスト</h2>
           <ul className="task-list">
             <li className="task-item">
               <label>

--- a/frontend/app/app/globals.css
+++ b/frontend/app/app/globals.css
@@ -11,7 +11,7 @@ html {
 }
 
 .calendar-contents {
-  width: 200px;
+  width: 240px;
   display: flex;
   align-items: center;
   margin-top: 20px;
@@ -72,19 +72,31 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
+  position: absolute;
+  /* top: 201px; */
+  bottom: 0;
+  right: 0;
+  left: 0;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* タスク一覧 */
 .main-tasks-monster-container {
+  position: relative  ;
+}
+.task-list-container {
+  width: 100%; /* タスクリスト全体の幅を100%に設定 */
   display: flex;
-  justify-content: center;
+  flex-direction: row; /* タスクリストを横並びに配置 */
+  justify-content: space-between; /* 左右に均等に配置 */
+  margin: 0 auto; /* 左右の余白を自動で均等に設定 */
+  max-width: 1200px; /* 最大幅を設定（必要に応じて調整） */
 }
 
-.task-list-container {
-  width: 400px;
-  display: flex;
-  flex-direction: column;
-  margin: 0 50px;
+.left-task-contents,
+.right-task-contents {
+  flex: 1; /* 左右のタスクリストを均等に伸縮させる */
 }
 
 .task-list {
@@ -96,7 +108,7 @@ body {
   display: flex;
   align-items: center;
   margin-bottom: 10px;
-  padding: 0 80px;
+  padding: 0 20px; /* 左右の余白を調整 */
 }
 
 .task-checkbox {
@@ -110,6 +122,14 @@ body {
   font-size: 18px;
 }
 
+.transparent-box {
+  width: 500px; /* 透明な箱の幅を設定 */
+  height: 500px; /* 透明な箱の高さを設定 */
+  background-color: transparent; /* 透明な背景 */
+  margin: 0 auto; /* 水平中央配置 */
+  margin-top: 24px; /* 上部マージンを設定 */
+}
+
 .exp-container {
   display: flex;
   flex-direction: column;
@@ -118,6 +138,7 @@ body {
   margin: auto;
   margin-top: 24px;
 }
+
 
 .exp-bar {
   width: 500px;

--- a/frontend/app/app/page.jsx
+++ b/frontend/app/app/page.jsx
@@ -14,7 +14,6 @@ export default function Home() {
       <div className="main-tasks-monster-container"> 
         <TaskList />
         <Monster />
-        <TaskList />
       </div>
       <ExpBar />
       <div className='footer'>


### PR DESCRIPTION
# プルリクエスト テンプレート

## 実施タスク

- タスクコンポーネントの設置数の変更
- タスクの表示を左右に表示
- モンスター（現状卵）を中心に設置

## 実施内容

- page.jsxのタスクが2個あった部分を一個に
- cssでタスクを左右両側に配置　（cssで真ん中に透明の箱を設置している状態）
- カレンダーを今日の日付で表示(表示のみでfigmaの状態とは異なっています、、、)

## レビューしてほしいこと
![image](https://github.com/Apprentice-Team-Dragon/reflect-monster/assets/124450112/4fbe2b60-ad4d-41e0-b256-0a4a0155165a)
添付した画像と同じ状態で表示される

他に良いcssの書き方があれば教えてください。

## 備考

- 表示のみでfigmaの状態とは異なっています。
- このブランチに関してはissueから切っていません。