### PR TITLE
fix: monsterへのgetリクエストで返ってくるデータ形式の修正

### DIFF
--- a/backend/app/controllers/api/monsters_controller.rb
+++ b/backend/app/controllers/api/monsters_controller.rb
@@ -2,7 +2,7 @@ class Api::MonstersController < ApplicationController
   before_action :set_monster, only: [:update]
 
   def get
-    render json: set_selected_monster
+    render json: set_selected_monster.generate_response
   end
 
   def create


### PR DESCRIPTION
# fix: monsterへのgetリクエストで返ってくるデータ形式の修正

## 実施タスク

issue #35 

## 実施内容

- monstersへのgetリクエストで返ってくるデータの形式を修正する。


## レビューしてほしいこと

- getのデータがpostやputで返ってくるデータと同一の形式で返ってくること

## 備考

- このプルリクはフロント側にも影響があるため、マージは一旦保留します。
