### PR TITLE
fix: monsterがseedを受け取らないので受け取るように修正

### DIFF
--- a/backend/app/controllers/api/monsters_controller.rb
+++ b/backend/app/controllers/api/monsters_controller.rb
@@ -13,6 +13,9 @@ class Api::MonstersController < ApplicationController
       prev_monster = Monster.find(params[:monsterId])
       prev_monster.update(is_selected: false)
       monster.set_evolution(prev_monster)
+      if monster.evolution_stage == 2
+        monster.set_seed_prev_monster(prev_monster)
+      end
     # 卵を生成する場合
     else
       set_egg_value(monster)
@@ -45,7 +48,7 @@ class Api::MonstersController < ApplicationController
     end
 
     def create_params
-      params.require(:monster).permit(:image)
+      params.require(:monster).permit(:image, :seed)
     end
     def update_params
       res = params.require(:monster).permit(:expPoint)

--- a/backend/app/models/monster.rb
+++ b/backend/app/models/monster.rb
@@ -61,9 +61,12 @@ class Monster < ApplicationRecord
   def set_evolution(prev_monster)
     self.species = prev_monster.species
     self.color = prev_monster.color
-    self.seed = prev_monster.seed
     self.evolution_stage = prev_monster.evolution_stage + 1
 
     self
+  end
+
+  def set_seed_prev_monster(prev_monster)
+    self.seed = prev_monster.seed
   end
 end

--- a/backend/db/migrate/20240203055859_change_seed_to_be_bigint_in_monsters.rb
+++ b/backend/db/migrate/20240203055859_change_seed_to_be_bigint_in_monsters.rb
@@ -1,0 +1,5 @@
+class ChangeSeedToBeBigintInMonsters < ActiveRecord::Migration[7.1]
+  def change
+    change_column :monsters, :seed, :bigint
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_30_095723) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_03_055859) do
   create_table "goals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.text "content", null: false
     t.boolean "is_completed", default: false
@@ -25,7 +25,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_30_095723) do
     t.integer "evolution_stage", null: false
     t.string "species", null: false
     t.string "color", null: false
-    t.integer "seed", default: 0, null: false
+    t.bigint "seed", default: 0, null: false
     t.boolean "is_selected", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# monster生成時にseed値を受け取る #40
## 実施タスク

issue #40 

## 実施内容

- seedカラムをintegerからbigintへ変更
- monsterIdが送られてこなければ卵を生成　seed=0
- monsterIdが送られてきた場合
  - 卵から孵化する場合はseedを設定
  - child monsterからadult monsterへの変化の場合は childの値をseedへ設定

## レビューしてほしいこと

- それぞれの進化段階でseedが正しく設定されること

## 備考

- seedのカラムがintegerだと4byteまでしか受け取らないというエラーが出たためカラムのデータ型をbigintへ変更しました。
