### PR TITLE
タスク作成、タスク取得修正

### DIFF
--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -178,11 +178,7 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.0-aarch64-linux)
       racc (~> 1.4)
-<<<<<<< Updated upstream
     nokogiri (1.16.0-arm64-darwin)
-=======
-    nokogiri (1.16.0-x86_64-darwin)
->>>>>>> Stashed changes
       racc (~> 1.4)
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)

--- a/backend/app/controllers/api/tasks_controller.rb
+++ b/backend/app/controllers/api/tasks_controller.rb
@@ -11,11 +11,10 @@ class Api::TasksController < ApplicationController
     render json: { task: task }, status: 201
   end
 
-  # タスクの更新がないので一旦コメントアウト
-  # def update
-  #   task = update_tasks(params[:tasks], @tasks)
-  #   render json: { task: task }, status: 201
-  # end
+  def update
+    task = update_tasks(params[:tasks], @tasks)
+    render json: { task: task }, status: 201
+  end
 
   private
     def set_goal_id

--- a/backend/app/controllers/api/tasks_controller.rb
+++ b/backend/app/controllers/api/tasks_controller.rb
@@ -3,30 +3,27 @@ class Api::TasksController < ApplicationController
   before_action :set_tasks, only: [:get, :update]
 
   def get
-    render_tasks(@tasks)
+    render json: { tasks: @tasks }, status: 200
   end
 
   def create
-    tasks = create_tasks(@goal_id, params[:tasks])
-    render_tasks(tasks)
+    task = create_task(params[:task])
+    render json: { task: task }, status: 201
   end
 
-  def update
-    tasks = update_tasks(params[:tasks], @tasks)
-    render_tasks(tasks)
-  end
+  # タスクの更新がないので一旦コメントアウト
+  # def update
+  #   task = update_tasks(params[:tasks], @tasks)
+  #   render json: { task: task }, status: 201
+  # end
 
   private
     def set_goal_id
-      @goal_id = params[:goalId]
+      @goal_id = params[:goal_id]
     end
 
     def set_tasks
-      @tasks = Task.where(goal_id: @goal_id, exec_date: params[:execDate])
-    end
-
-    def render_tasks(tasks)
-      render json: { tasks: tasks.map { |ele| ele.generate_response } }
+      @tasks = Task.where(goal_id: @goal_id, exec_date: params[:exec_date])
     end
 
     def create_update_params(task)
@@ -34,12 +31,12 @@ class Api::TasksController < ApplicationController
       transform_camel_to_snake(use_params).permit!
     end
 
-    def create_tasks(goal_id, tasks)
-      tasks.map do |task|
-        new_task = Task.new(goal_id:, content: task[:content], exec_date: task[:execDate])
-        new_task.save
-        new_task
-      end
+    def create_task(task)
+      Task.create(
+        goal_id: @goal_id,
+        content: task["content"],
+        exec_date: task["exec_date"]
+      )
     end
 
     def update_tasks(tasks, base_tasks)

--- a/frontend/app/app/components/AddTaskModal.jsx
+++ b/frontend/app/app/components/AddTaskModal.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import Modal from "react-modal";
 import { Box, Button } from "@mui/material";
 import TextField from "@mui/material/TextField";
@@ -14,6 +14,11 @@ const modalStyle = {
 };
 
 export default function AddTaskModal({ isModalOpen, onClickCloseButton, onClickCreateButton }) {
+  const [text, setText] = useState('');
+  const handleChange = (e) => {
+    setText(() => e.target.value)
+  }
+
   return (
     <Modal isOpen={isModalOpen} style={modalStyle}>
       <Button variant="outlined" onClick={onClickCloseButton}>
@@ -24,13 +29,13 @@ export default function AddTaskModal({ isModalOpen, onClickCloseButton, onClickC
         タスクを追加する
       </Box>
       <Box textAlign="center" width="80%" margin="24px auto">
-        <TextField type="text" name="aaa" style={{ width: "100%" }} />
+        <TextField onChange={handleChange}  type="text" name="aaa" style={{ width: "100%" }} />
       </Box>
 
       <Box textAlign="center" marginTop="32px">
         <Button
           variant="outlined"
-          onClick={onClickCreateButton}
+          onClick={()=>onClickCreateButton(text)}
           style={{ width: "60%", padding: "8px 0" }}
         >
           保存

--- a/frontend/app/app/components/Goal.jsx
+++ b/frontend/app/app/components/Goal.jsx
@@ -24,7 +24,7 @@ export default function Goal() {
   return (
     <div className="mission">
       <div className="mission-contents">
-        <p>{goal?.content}</p>
+        {/* <p>{goal?.content}</p> */}
       </div>
     </div>
   );

--- a/frontend/app/app/components/TaskList/ index.jsx
+++ b/frontend/app/app/components/TaskList/ index.jsx
@@ -3,19 +3,21 @@ import TaskItem from "./TaskItem";
 import "./style.scss";
 
 // TaskList コンポーネントの定義
-const TaskList = ({ animationClass }) => {
+const TaskList = ({ tasks, animationClass }) => {
   return (
     <div className="task-list-container">
       <div className="main-content-task-left">
         <div className="left-task-contents">
           <h2>左側のタスクリスト</h2>
           <div className="container">
-            <TaskItem
-              onComplete={null}
-              id="one"
-              label="Choice One"
-              animationClass={animationClass}
-            />
+            {tasks.map((task) => (
+              <TaskItem
+                onComplete={null}
+                id={`task${task.id}`}
+                label={task.content}
+                animationClass={animationClass}
+              />
+            ))}
           </div>
         </div>
       </div>

--- a/frontend/app/utils/dateUtil.js
+++ b/frontend/app/utils/dateUtil.js
@@ -1,0 +1,13 @@
+export function formatDate(date) {
+  let d = new Date(date),
+    month = "" + (d.getMonth() + 1),
+    day = "" + d.getDate(),
+    year = d.getFullYear();
+
+  if (month.length < 2) month = "0" + month;
+  if (day.length < 2) day = "0" + day;
+
+  return [year, month, day].join("-");
+
+  // console.log(formatDate(new Date()));
+}


### PR DESCRIPTION
# プルリクエスト テンプレート

## 実施タスク

- none

## 実施内容

- フロントでタスクを取得できるように
- フロントのフッターにあるタスク追加ボタンを押してタスクを追加できるように
  - 上記２つに伴いAPIも一部修正

## レビューしてほしいこと

- tasks_controllerの修正内容に不備がないこと、誰の環境でも同じようにタスクの取得、作成のリクエストが成功すること

## 備考

- rubocop, eslint未実施です
