### PR TITLE
fix: 卵生成時にimageにfirstegg.pngに設定されるようにする

### DIFF
--- a/backend/app/controllers/api/monsters_controller.rb
+++ b/backend/app/controllers/api/monsters_controller.rb
@@ -57,7 +57,7 @@ class Api::MonstersController < ApplicationController
     end
 
     def set_egg_value(monster)
-      monster.set_random_color.set_random_image.set_random_species.set_max_exp.set_evolution_zero.set_seed_zero
+      monster.set_random_color.set_initial_egg.set_random_species.set_max_exp.set_evolution_zero.set_seed_zero
       monster
     end
 end

--- a/backend/app/models/monster.rb
+++ b/backend/app/models/monster.rb
@@ -21,7 +21,7 @@ class Monster < ApplicationRecord
   end
 
   def set_initial_egg
-    self.image = "firstedd.png"
+    self.image = "firstegg.png"
     self
   end
 

--- a/backend/app/models/monster.rb
+++ b/backend/app/models/monster.rb
@@ -20,6 +20,11 @@ class Monster < ApplicationRecord
     self
   end
 
+  def set_initial_egg
+    self.image = "firstedd.png"
+    self
+  end
+
   def set_random_image
     egg_images = %w(egg1 egg2 egg3 egg4 egg5 egg6)
 


### PR DESCRIPTION
# fix: 卵生成時にimageにfirstegg.pngに設定されるようにする

## 実施タスク

issue #46 

## 実施内容

- monsterの卵生成時のimageの値をfirstegg.pngに固定した。

## レビューしてほしいこと

- 卵生成時にfirstegg.pngにimageが固定されていること

## 備考

- 特になし
