### PR TITLE
Feature/#47 add exp point to monster

### DIFF
--- a/frontend/app/app/components/ExpBar.jsx
+++ b/frontend/app/app/components/ExpBar.jsx
@@ -1,40 +1,16 @@
 export default function ExpBar({
   useMonsterState,
-  currentExpPoint,
-  hundleAddExpPoint,
-  hundleReduceExpPoint,
-  hundleTrueIsAddExpPoint,
+
 }) {
-  const { monster, isLoading, hundleMonsterExpPoint } = useMonsterState;
-  const hundleExpPoint = (currentExpPoint) => {
-    hundleMonsterExpPoint(currentExpPoint);
-    hundleTrueIsAddExpPoint();
-  };
+  const { monster, isLoading } = useMonsterState;
 
   return (
     <div className="exp-container">
       <div className="exp-bar-text">
         次の成長まで「
         {isLoading ? "..." : monster?.max_exp_point - monster.exp_point}」
-        {currentExpPoint === monster?.exp_point ? null : (
-          <button onClick={() => hundleReduceExpPoint()}>-</button>
-        )}
-        {currentExpPoint === monster?.max_exp_point ? null : (
-          <button onClick={() => hundleAddExpPoint()}>+</button>
-        )}
-        <div>
-          {currentExpPoint > monster?.exp_point ? (
-            <button onClick={() => hundleExpPoint(currentExpPoint)}>
-              経験値を「{currentExpPoint - monster?.exp_point}」与える
-            </button>
-          ) : null}
-          {/* {monster?.exp_point >= monster?.max_exp_point ? (
-            <button>モンスター進化</button>
-          ) : null} */}
-        </div>
       </div>
       <div className="exp-bar" />
-      現在の経験値 「{monster?.exp_point}」
     </div>
   );
 }

--- a/frontend/app/app/components/Menu.jsx
+++ b/frontend/app/app/components/Menu.jsx
@@ -1,6 +1,9 @@
 export default function Menu({
   onClickAddTaskButton,
   useTasksState,
+  useMonsterState,
+  currentExpPoint,
+  hundleTrueIsAddExpPoint,
 }) {
   const {
     tasks,
@@ -12,6 +15,12 @@ export default function Menu({
     hundleCompletedTasks,
     hundleRemovedTasks,
   } = useTasksState;
+  const { hundleMonsterExpPoint } = useMonsterState;
+  const hundleExpPoint = (tasks, currentExpPoint) => {
+    hundleRemovedTasks(tasks)
+    hundleMonsterExpPoint(currentExpPoint);
+    hundleTrueIsAddExpPoint();
+  };
   if (tasks) {
     return (
       <div>
@@ -25,7 +34,7 @@ export default function Menu({
               <img src="img/taskadd.png" alt="タスク追加" />
               <span>タスク追加</span>
             </li>
-            <li className="menu-item" onClick={() => hundleRemovedTasks(tasks)}>
+            <li className="menu-item" onClick={() => hundleExpPoint(tasks, currentExpPoint)}>
               <img src="img/taskdone.png" alt="タスク完了" />
               <span>タスク完了</span>
             </li>

--- a/frontend/app/app/components/Monster.jsx
+++ b/frontend/app/app/components/Monster.jsx
@@ -3,7 +3,7 @@ import { CircularProgress, LinearProgress } from "@mui/material";
 
 export default function Monster({useMonsterState, generateMonsterInfo}) {
   const { monster, isLoading, hasError, errorMessage } = useMonsterState;
-  const { isGenerating, haGenerateError } = generateMonsterInfo;
+  const { isGenerating, hasGenerateError } = generateMonsterInfo;
 
   if (isLoading || isGenerating) {
     return (
@@ -34,6 +34,7 @@ export default function Monster({useMonsterState, generateMonsterInfo}) {
           alt="monster_image"
           width={400}
           height={400}
+          priority="high"
         />
       </div>
     );

--- a/frontend/app/app/components/TaskList/ index.jsx
+++ b/frontend/app/app/components/TaskList/ index.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React from "react";
 import TaskItem from "./TaskItem";
-import './style.scss';
+import "./style.scss";
 import { CircularProgress } from "@mui/material";
 
 // TaskItem コンポーネントの定義
@@ -13,7 +13,12 @@ import { CircularProgress } from "@mui/material";
 // );
 
 // TaskList コンポーネントの定義
-const TaskList = ({ useTasksState, animationClass }) => {
+const TaskList = ({
+  useTasksState,
+  animationClass,
+  hundleAddExpPoint,
+  hundleReduceExpPoint,
+}) => {
   const {
     tasks,
     isLoading,
@@ -21,7 +26,7 @@ const TaskList = ({ useTasksState, animationClass }) => {
     errorMessage,
     hundleCreateTasks,
     hundleUpdateTasks,
-    hundleCompletedTasks
+    hundleCompletedTasks,
   } = useTasksState;
 
   if (isLoading) {
@@ -29,7 +34,6 @@ const TaskList = ({ useTasksState, animationClass }) => {
       <div className="task-list-container">
         <div className="main-content-task-left">
           <div className="left-task-contents">
-            <h2>左側のタスクリスト</h2>
             <div className="container">
               <CircularProgress />
             </div>
@@ -40,7 +44,6 @@ const TaskList = ({ useTasksState, animationClass }) => {
         </div>
         <div className="main-content-task-right">
           <div className="right-task-contents">
-            <h2>右側のタスクリスト</h2>
             <div className="container">
               <CircularProgress />
             </div>
@@ -59,10 +62,18 @@ const TaskList = ({ useTasksState, animationClass }) => {
       <div className="task-list-container">
         <div className="main-content-task-left">
           <div className="left-task-contents">
-            <h2>左側のタスクリスト</h2>
             <div className="container">
               {leftTasks.map((task, index) => (
-                <TaskItem key={index} id={index} tasks={tasks} task={task} hundleCompletedTasks={hundleCompletedTasks} animationClass={animationClass}/>
+                <TaskItem
+                  key={index}
+                  id={index}
+                  tasks={tasks}
+                  task={task}
+                  hundleCompletedTasks={hundleCompletedTasks}
+                  animationClass={animationClass}
+                  hundleAddExpPoint={hundleAddExpPoint}
+                  hundleReduceExpPoint={hundleReduceExpPoint}
+                />
               ))}
             </div>
           </div>
@@ -75,10 +86,18 @@ const TaskList = ({ useTasksState, animationClass }) => {
             <CircularProgress />
           ) : (
             <div className="right-task-contents">
-              <h2>右側のタスクリスト</h2>
               <div className="container">
                 {rightTasks.map((task, index) => (
-                  <TaskItem key={index + middleIndex} id={index + middleIndex} tasks={tasks} task={task} hundleCompletedTasks={hundleCompletedTasks} animationClass={animationClass} />
+                  <TaskItem
+                    key={index + middleIndex}
+                    id={index + middleIndex}
+                    tasks={tasks}
+                    task={task}
+                    hundleCompletedTasks={hundleCompletedTasks}
+                    animationClass={animationClass}
+                    hundleAddExpPoint={hundleAddExpPoint}
+                    hundleReduceExpPoint={hundleReduceExpPoint}
+                  />
                 ))}
               </div>
             </div>

--- a/frontend/app/app/components/TaskList/ index.jsx
+++ b/frontend/app/app/components/TaskList/ index.jsx
@@ -65,7 +65,8 @@ const TaskList = ({
             <div className="container">
               {leftTasks.map((task, index) => (
                 <TaskItem
-                  key={index}
+                  key={task.id}
+                  itemKey={task.id}
                   id={index}
                   tasks={tasks}
                   task={task}
@@ -89,7 +90,8 @@ const TaskList = ({
               <div className="container">
                 {rightTasks.map((task, index) => (
                   <TaskItem
-                    key={index + middleIndex}
+                    key={task.id + middleIndex}
+                    itemKey={task.id + middleIndex}
                     id={index + middleIndex}
                     tasks={tasks}
                     task={task}

--- a/frontend/app/app/components/TaskList/TaskItem.jsx
+++ b/frontend/app/app/components/TaskList/TaskItem.jsx
@@ -1,20 +1,38 @@
 import "./style.scss";
 
-const TaskItem = ({ key, id, tasks, task, hundleCompletedTasks, hundleAddExpPoint, hundleReduceExpPoint }) => {
+const TaskItem = ({
+  itemKey,
+  id,
+  tasks,
+  task,
+  hundleCompletedTasks,
+  hundleAddExpPoint,
+  hundleReduceExpPoint,
+}) => {
   const hundleChecked = (tasks, id, isCompleted) => {
     if (isCompleted) {
-      hundleReduceExpPoint()
+      hundleReduceExpPoint();
     } else {
-      hundleAddExpPoint()
+      hundleAddExpPoint();
     }
     hundleCompletedTasks(tasks, id);
-  }
+  };
   return (
-  <div key={key} className={`check-container ${task.isRemoved ? "moveToEgg" : ""}`} onChange={() => hundleChecked(tasks, id, task.isCompleted)}>
-    <input type="checkbox" id={id} value={task.isCompleted} checked={task.isCompleted}/>
-    <label htmlFor={id}></label>
-    <span className="tag">{task.content}</span>
-  </div>
+    <div
+      key={itemKey}
+      className={`check-container ${task.isRemoved ? "moveToEgg" : ""}`}
+      onChange={() => hundleChecked(tasks, id, task.isCompleted)}
+    >
+      <input
+        type="checkbox"
+        id={id}
+        value={task.isCompleted}
+        // checked={task.isCompleted}
+        defaultChecked={task.isCompleted}
+      />
+      <label htmlFor={id}></label>
+      <span className="tag">{task.content}</span>
+    </div>
   );
 };
 

--- a/frontend/app/app/components/TaskList/TaskItem.jsx
+++ b/frontend/app/app/components/TaskList/TaskItem.jsx
@@ -1,9 +1,16 @@
 import "./style.scss";
 
-const TaskItem = ({ key, id, tasks, task, hundleCompletedTasks }) => {
-
+const TaskItem = ({ key, id, tasks, task, hundleCompletedTasks, hundleAddExpPoint, hundleReduceExpPoint }) => {
+  const hundleChecked = (tasks, id, isCompleted) => {
+    if (isCompleted) {
+      hundleReduceExpPoint()
+    } else {
+      hundleAddExpPoint()
+    }
+    hundleCompletedTasks(tasks, id);
+  }
   return (
-  <div key={key} className={`check-container ${task.isRemoved ? "moveToEgg" : ""}`} onChange={() => hundleCompletedTasks(tasks, id)}>
+  <div key={key} className={`check-container ${task.isRemoved ? "moveToEgg" : ""}`} onChange={() => hundleChecked(tasks, id, task.isCompleted)}>
     <input type="checkbox" id={id} value={task.isCompleted} checked={task.isCompleted}/>
     <label htmlFor={id}></label>
     <span className="tag">{task.content}</span>

--- a/frontend/app/app/page.jsx
+++ b/frontend/app/app/page.jsx
@@ -56,7 +56,8 @@ export default function Home() {
   const { generateMonsterInfo } = useGenerateMonster(
     useMonsterState.monster,
     useMonsterState.hundleMonsterImage,
-    useMonsterState.hundleMonsterExpPoint
+    useMonsterState.hundleMonsterExpPoint,
+    goalId
   );
 
   const { useTasksState } = useTasks(goalId, execDate);
@@ -80,6 +81,8 @@ export default function Home() {
             useTasksState={useTasksState}
             animationClass={animationClasses["tasks"]}
             onClickCompleteTasks={handleClickCompleteButton}
+            hundleAddExpPoint={() => hundleAddExpPoint()}
+            hundleReduceExpPoint={() => hundleReduceExpPoint()}
           />
           <Monster
             animationClass={animationClasses["monster"]}
@@ -100,6 +103,9 @@ export default function Home() {
             onClickAddTaskButton={() => setModalIsOpen(true)}
             onClickCompleteButton={handleClickCompleteButton}
             useTasksState={useTasksState}
+            useMonsterState={useMonsterState}
+            currentExpPoint={currentExpPoint}
+            hundleTrueIsAddExpPoint={hundleTrueIsAddExpPoint}
           />
         </div>
       </div>

--- a/frontend/app/hooks/MonsterHooks/useGenerateMonster.js
+++ b/frontend/app/hooks/MonsterHooks/useGenerateMonster.js
@@ -30,7 +30,7 @@ export function useGenerateMonster(
         setIsGenerating(false);
       }
     };
-    if (monster.exp_point >= monster.max_exp_point && monster.evolution_satage !== 2) {
+    if (monster.exp_point >= monster.max_exp_point && monster.evolution_stage !== 2) {
       console.log(`id=${monster.id}のモンスターを進化します`);
       hundleGenerateMonster();
     }

--- a/frontend/app/hooks/MonsterHooks/useGenerateMonster.js
+++ b/frontend/app/hooks/MonsterHooks/useGenerateMonster.js
@@ -5,7 +5,8 @@ import { getGoalText, postMonster } from "../../utils/api/monsterApi";
 export function useGenerateMonster(
   monster,
   hundleMonsterImage,
-  hundleMonsterExpPoint
+  hundleMonsterExpPoint,
+  goalId
 ) {
   const [isGenerating, setIsGenerating] = useState(false);
   const [hasGenerateError, setHasGenerateError] = useState(false);
@@ -15,20 +16,21 @@ export function useGenerateMonster(
       // TODO ここで、モンスターの経験値をデータベースに保存 DBの値を使って進化できるか判定する
       setIsGenerating(true);
       try {
-        const goalContent = await getGoalText(2);
-        const { imagePath, seed } = await generateMonster(goalContent, monster);
+        const goalContent = await getGoalText(goalId);
+        const { imagePath, seedValue } = await generateMonster(goalContent, monster);
 
         hundleMonsterImage(imagePath);
         hundleMonsterExpPoint(0);
-        postMonster(monster.id, imagePath);
-        console.log(seed);
+        postMonster(monster.id, imagePath, seedValue);
+        console.log(seedValue);
+
       } catch (error) {
         setHasGenerateError(true);
       } finally {
         setIsGenerating(false);
       }
     };
-    if (monster.exp_point >= monster.max_exp_point) {
+    if (monster.exp_point >= monster.max_exp_point && monster.evolution_satage !== 2) {
       console.log(`id=${monster.id}のモンスターを進化します`);
       hundleGenerateMonster();
     }

--- a/frontend/app/utils/api/monster.js
+++ b/frontend/app/utils/api/monster.js
@@ -148,22 +148,22 @@ async function uploadImage(base64Image) {
 // モンスター生成の一連の処理 monster objectを返す
 export async function generateMonster(goalContent, {evolution_stage, animal, color, seed} = monster) {
 
-  let topLabel = "base";
-  if (evolution_stage === 1) {
-    const categoryData = await getGoalCategory(goalContent);
-    const labelArray = categoryData.labels.map((label, index) => ({
-      label: label,
-      score: categoryData.scores[index],
-    }));
-    topLabel = labelArray.sort((a, b) => (a.score > b.score ? -1 : 1))[0][
-      "label"
-    ];
-  } else if (evolution_stage > 2) {
-    throw new Error("evolutionStage only accept 0 or 1");
-  }
+  // let topLabel = "base";
+  // if (evolution_stage === 1) {
+  //   const categoryData = await getGoalCategory(goalContent);
+  //   const labelArray = categoryData.labels.map((label, index) => ({
+  //     label: label,
+  //     score: categoryData.scores[index],
+  //   }));
+  //   topLabel = labelArray.sort((a, b) => (a.score > b.score ? -1 : 1))[0][
+  //     "label"
+  //   ];
+  // } else if (evolution_stage > 2) {
+  //   throw new Error("evolutionStage only accept 0 or 1");
+  // }
 
   const monsterImageBase64 = await generateMonsterImage(
-    topLabel,
+    "sports",
     animal,
     color,
     seed
@@ -172,11 +172,11 @@ export async function generateMonster(goalContent, {evolution_stage, animal, col
   const generatedImage = monsterImageBase64.artifacts[0].base64;
 
   //TODO 画像背景透過処理 本番では動作させる
-  // const removeBackgroundData = await removeBackground(generatedImage);
-  // const removeBackgroundImage = removeBackgroundData.data.result_b64;
-  // const imagePath = await uploadImage(removeBackgroundImage);
+  const removeBackgroundData = await removeBackground(generatedImage);
+  const removeBackgroundImage = removeBackgroundData.data.result_b64;
+  const imagePath = await uploadImage(removeBackgroundImage);
 
-  const imagePath = await uploadImage(generatedImage);
+  // const imagePath = await uploadImage(generatedImage);
 
   return { imagePath, seedValue };
 }

--- a/frontend/app/utils/api/monsterApi.js
+++ b/frontend/app/utils/api/monsterApi.js
@@ -51,10 +51,11 @@ export async function addExpPoint(monsterId, expPoint) {
 // TODO 卵生成用の関数を作成する
 
 // モンスター進化
-export async function postMonster(monsterId, imagePath) {
+export async function postMonster(monsterId, imagePath, seedValue) {
   const url = `${process.env.NEXT_PUBLIC_API_URL}/api/monsters?monsterId=${monsterId}`;
   const raw = JSON.stringify({
     image: imagePath,
+    seed: seedValue,
   });
   const config = {
     method: "POST",


### PR DESCRIPTION
# タスクの完了によってモンスターへ経験値を付与

## 実施タスク

例：issue #47 

## 実施内容

- タスク完了によってモンスターに経験値を付与する機能
- 付与された経験値によってモンスターが進化する機能

## レビューしてほしいこと

- 選択されたタスクが完了となり、タスク一つにつきモンスターが経験値を1取得すること
- max_exp_pointになったら、進化し画面に表示されること


## 備考

- 文章からカテゴリを選択する機能は、リクエスト数の制限に引っかかっているので、コメントアウトしています。現在、どんな目標やタスクを入力していても、"sports"カテゴリとして処理されるようになっています。
- URLは、`http://localhost:4000/?goalId=2&execDate=2024-02-04`の形式で表示させてください。
- DBに目標、タスク、モンスター（卵）が保存されていない場合、正常に動作しません。目標と、それに紐づくタスク、imageが「firstegg.png」でis_selectedがtrue、exp_pointが0となるモンスターデータを一つだけ入れた状態にしてください。

