### PR TITLE
add: 経験値バーにアニメーションを追加

### DIFF
--- a/frontend/app/app/components/ExpBar.jsx
+++ b/frontend/app/app/components/ExpBar.jsx
@@ -1,16 +1,38 @@
-export default function ExpBar({
-  useMonsterState,
+import { styled } from "@mui/material/styles";
+import Grid from "@mui/material/Grid";
 
-}) {
+import LinearProgress, {
+  linearProgressClasses,
+} from "@mui/material/LinearProgress";
+
+const BorderLinearProgress = styled(LinearProgress)({
+  width: 600,
+  height: 50,
+  borderRadius: 10,
+  backgroundColor: "#999999",
+  [`& .${linearProgressClasses.bar}`]: {
+    borderRadius: 10,
+    backgroundColor: "#33CD32",
+  },
+});
+
+export default function ExpBar({ useMonsterState }) {
   const { monster, isLoading } = useMonsterState;
 
+  if (isLoading) {
+    return null;
+  }
+
   return (
-    <div className="exp-container">
-      <div className="exp-bar-text">
-        次の成長まで「
-        {isLoading ? "..." : monster?.max_exp_point - monster.exp_point}」
-      </div>
-      <div className="exp-bar" />
-    </div>
+    <Grid container direction="row" justifyContent="center" alignItems="center">
+      <BorderLinearProgress
+        variant="determinate"
+        value={
+          monster.exp_point >= monster.max_exp_point
+            ? 100
+            : Math.floor((monster.exp_point * 100) / monster.max_exp_point)
+        }
+      />
+    </Grid>
   );
 }


### PR DESCRIPTION
# 経験値バーにアニメーションを追加

## 実施タスク

例：issue #50 

## 実施内容

- muiのLinearProgressで経験値バーのアニメーションを実装

## レビューしてほしいこと

- タスクを完了するとその分だけ経験値バーが動く
- 100%になると、それ以上タスクを完了させてもバーは動かない（100%のまま）

## 備考

デザインの変更は、`components/expBar.jsx`の以下の部分で変更できます。
```js
const BorderLinearProgress = styled(LinearProgress)({
  width: 600,
  height: 50,
  borderRadius: 10,
  backgroundColor: "#999999",
  [`& .${linearProgressClasses.bar}`]: {
    borderRadius: 10,
    backgroundColor: "#33CD32",
  },
});
```
