### PR TITLE
fix: モンスター生成のロジックを修正

### DIFF
--- a/frontend/app/utils/api/monster.js
+++ b/frontend/app/utils/api/monster.js
@@ -162,8 +162,17 @@ export async function generateMonster(goalContent, {evolution_stage, animal, col
   //   throw new Error("evolutionStage only accept 0 or 1");
   // }
 
+  let topLabel = "";
+  if (evolution_stage === 0) {
+  topLabel = "base";
+  } else if (evolution_stage === 1) {
+    topLabel = "sports"
+  } else if (evolution_stage >= 2) {
+    throw new Error("evolutionStage only accept 0 or 1");
+  }
+
   const monsterImageBase64 = await generateMonsterImage(
-    "sports",
+    topLabel,
     animal,
     color,
     seed


### PR DESCRIPTION
# 1体目のモンスターが進化後の姿になる不具合を修正

## 実施タスク

例：issue #54 

## 実施内容

- モンスター進化の不具合を修正

## レビューしてほしいこと

- 孵化するときに幼いモンスターが生成される
- 進化するときには、成長した姿が生成される

## 備考

- なし
